### PR TITLE
fix(receiver/holoinsight_skywalking): fix duplicated span id

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Which issue does this PR close?
+
+Closes #
+
+# Rationale for this change
+ 
+<!---
+ Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
+ Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
+-->
+
+# What changes are included in this PR?
+
+<!---
+There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
+-->
+
+# Are there any user-facing changes?
+
+<!---
+Please mention if:
+
+- there are user-facing changes that need to update the documentation or configuration.
+- this is a breaking change to public APIs
+-->
+
+# How does this change test
+
+<!-- 
+Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
+-->

--- a/receiver/holoinsightskywalkingreceiver/skywalkingproto_to_traces.go
+++ b/receiver/holoinsightskywalkingreceiver/skywalkingproto_to_traces.go
@@ -16,6 +16,7 @@ package holoinsightskywalkingreceiver // import "github.com/open-telemetry/opent
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
 	"reflect"
 	"strconv"
@@ -410,10 +411,15 @@ func swStringToUUID(s string, extra uint32) (dst [16]byte) {
 
 func uuidTo8Bytes(uuid [16]byte) [8]byte {
 	// high bit XOR low bit
+	// XOR has a probability to generate the same id
+	//var dst [8]byte
+	//for i := 0; i < 8; i++ {
+	//	dst[i] = uuid[i] ^ uuid[i+8]
+	//}
+
 	var dst [8]byte
-	for i := 0; i < 8; i++ {
-		dst[i] = uuid[i] ^ uuid[i+8]
-	}
+	hash := sha256.Sum256(uuid[:])
+	copy(dst[:], hash[:8])
 	return dst
 }
 

--- a/receiver/holoinsightskywalkingreceiver/skywalkingproto_to_traces_test.go
+++ b/receiver/holoinsightskywalkingreceiver/skywalkingproto_to_traces_test.go
@@ -15,6 +15,7 @@
 package holoinsightskywalkingreceiver
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -55,6 +56,19 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			assert.Equal(t, test.code, test.dest.Code())
 		})
 	}
+}
+
+func TestSegmentIdToSpanId(t *testing.T) {
+	segmentId := "de88986043c0471f82eb7df8ea26e9e5.117.16818972022146612"
+	spanId := 0
+	id := segmentIDToSpanID(segmentId, uint32(spanId))
+	fmt.Println(id)
+
+	segmentId1 := "de88986043c0471f82eb7df8ea26e9e5.117.16818972022146614"
+	spanId1 := 2
+	id1 := segmentIDToSpanID(segmentId1, uint32(spanId1))
+	fmt.Println(id1)
+	assert.NotEqual(t, id, id1)
 }
 
 func TestSwKvPairsToInternalAttributes(t *testing.T) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
- Different segmentId and spanId have a probability to generate the same spanId
```
func TestSegmentIdToSpanId(t *testing.T) {
	segmentId := "de88986043c0471f82eb7df8ea26e9e5.117.16818972022146612"
	spanId := 0
	id := segmentIDToSpanID(segmentId, uint32(spanId))
	fmt.Println(id)

	segmentId1 := "de88986043c0471f82eb7df8ea26e9e5.117.16818972022146614"
	spanId1 := 2
	id1 := segmentIDToSpanID(segmentId1, uint32(spanId1))
	fmt.Println(id1)
}
```
```
=== RUN TestSegmentIdToSpanId
68653b8c182695fa
68653b8c182695fa
--- PASS: TestSegmentIdToSpanId (0.00s)
```

- Hash method to generate spanId
